### PR TITLE
Fix issue importing only certain trello lists

### DIFF
--- a/server/handlers/api.js
+++ b/server/handlers/api.js
@@ -338,7 +338,9 @@ export default async function handler(req, res, next) {
                     return obj;
                 }, {});
                 const listIdToCardsMap = cards.reduce((lists, card) => {
-                    lists[card.idList].push(card);
+                    if (typeof lists[card.idList] !== 'undefined') {
+                        lists[card.idList].push(card);
+                    }
                     return lists;
                 }, emptyListObj);
                 const mergedLists = getProjectInfo(listInfo, listIdToCardsMap);


### PR DESCRIPTION
Previously when choosing only certain Trello lists to import, an error resulted. This seems to do the trick, only adding cards for lists that are selected.

And thank you so much for such a great little app!